### PR TITLE
feat: add PIT + search_after pagination support (SUPPORT-16414)

### DIFF
--- a/component_config/configRowSchema.json
+++ b/component_config/configRowSchema.json
@@ -108,6 +108,35 @@
             "type": "boolean",
             "default": false,
             "propertyOrder": 700
+        },
+        "search_method": {
+            "title": "Search Method",
+            "description": "Choose the pagination method for extracting data. <strong>Scroll API</strong> is the legacy default. <strong>PIT + search_after</strong> uses Point-in-Time snapshots and is recommended for Elasticsearch 7.10+ as it is more efficient for large datasets and avoids keeping scroll contexts open.",
+            "type": "string",
+            "enum": [
+                "scroll",
+                "search_after"
+            ],
+            "default": "scroll",
+            "options": {
+                "enum_titles": [
+                    "Scroll API",
+                    "PIT + search_after"
+                ]
+            },
+            "propertyOrder": 800
+        },
+        "pit_keep_alive": {
+            "title": "PIT Keep Alive",
+            "description": "How long the Point-in-Time snapshot should be kept alive between pagination requests (e.g. <code>5m</code>, <code>10m</code>). Only applies when using <strong>PIT + search_after</strong> method.",
+            "type": "string",
+            "default": "5m",
+            "propertyOrder": 900,
+            "options": {
+                "dependencies": {
+                    "search_method": "search_after"
+                }
+            }
         }
     }
 }

--- a/src/client/es_client.py
+++ b/src/client/es_client.py
@@ -76,13 +76,15 @@ class ElasticsearchClient(Elasticsearch):
                 search_body["sort"] = [{"_shard_doc": "asc"}]
 
             response = self.search(body=search_body)
+            pit_id = response.get("pit_id", pit_id)
             for r in self._process_response(response, include_meta_fields):
                 yield r
 
             while len(response["hits"]["hits"]):
                 last_hit = response["hits"]["hits"][-1]
                 search_body["search_after"] = last_hit["sort"]
-                search_body["pit"] = {"id": response.get("pit_id", pit_id), "keep_alive": keep_alive}
+                pit_id = response.get("pit_id", pit_id)
+                search_body["pit"] = {"id": pit_id, "keep_alive": keep_alive}
 
                 response = self.search(body=search_body)
                 for r in self._process_response(response, include_meta_fields):

--- a/src/client/es_client.py
+++ b/src/client/es_client.py
@@ -7,6 +7,7 @@ from elasticsearch.exceptions import ApiError, TransportError
 
 DEFAULT_SIZE = 10_000
 SCROLL_TIMEOUT = "15m"
+DEFAULT_PIT_KEEP_ALIVE = "5m"
 
 
 class ElasticsearchClientException(Exception):
@@ -31,7 +32,7 @@ class ElasticsearchClient(Elasticsearch):
 
     def extract_data(self, index_name: str, query: str, include_meta_fields: bool = False) -> Iterable:
         """
-        Extracts data from the specified Elasticsearch index based on the given query.
+        Extracts data using the Scroll API.
 
         Parameters:
             index_name (str): Name of the Elasticsearch index.
@@ -49,6 +50,48 @@ class ElasticsearchClient(Elasticsearch):
             response = self.scroll(scroll_id=response["_scroll_id"], scroll=SCROLL_TIMEOUT)
             for r in self._process_response(response, include_meta_fields):
                 yield r
+
+    def extract_data_pit(
+        self, index_name: str, query: dict, include_meta_fields: bool = False, keep_alive: str = DEFAULT_PIT_KEEP_ALIVE
+    ) -> Iterable:
+        """
+        Extracts data using PIT (Point-in-Time) + search_after pagination.
+
+        Parameters:
+            index_name (str): Name of the Elasticsearch index.
+            query (dict): Elasticsearch DSL query.
+            include_meta_fields (bool): When True, merges ES metadata fields into each row.
+            keep_alive (str): How long the PIT should be kept alive between requests.
+
+        Yields:
+            dict
+        """
+        pit = self.open_point_in_time(index=index_name, keep_alive=keep_alive)
+        pit_id = pit["id"]
+
+        try:
+            search_body = {**query, "size": DEFAULT_SIZE, "pit": {"id": pit_id, "keep_alive": keep_alive}}
+
+            if "sort" not in search_body:
+                search_body["sort"] = [{"_shard_doc": "asc"}]
+
+            response = self.search(body=search_body)
+            for r in self._process_response(response, include_meta_fields):
+                yield r
+
+            while len(response["hits"]["hits"]):
+                last_hit = response["hits"]["hits"][-1]
+                search_body["search_after"] = last_hit["sort"]
+                search_body["pit"] = {"id": response.get("pit_id", pit_id), "keep_alive": keep_alive}
+
+                response = self.search(body=search_body)
+                for r in self._process_response(response, include_meta_fields):
+                    yield r
+        finally:
+            try:
+                self.close_point_in_time(id=pit_id)
+            except (ApiError, TransportError):
+                pass
 
     def _process_response(self, response: dict, include_meta_fields: bool = False) -> Iterable:
         for hit in response["hits"]["hits"]:

--- a/src/component.py
+++ b/src/component.py
@@ -15,7 +15,7 @@ from keboola.utils.header_normalizer import NormalizerStrategy, get_normalizer
 from client.es_client import ElasticsearchClient
 from client.ssh_tunnel import SshTunnel, SshTunnelError
 from client.ssh_utils import SomeSSHException, get_private_key
-from configuration import AuthType, Configuration
+from configuration import AuthType, Configuration, SearchMethod
 from legacy_client.legacy_es_client import LegacyClient
 
 LOCAL_BIND_ADDRESS = "127.0.0.1"
@@ -68,8 +68,21 @@ class Component(ComponentBase):
         )
 
         try:
+            if config.search_method == SearchMethod.search_after:
+                logging.info("Using PIT + search_after pagination.")
+                data_iter = client.extract_data_pit(
+                    index_name, query,
+                    include_meta_fields=config.include_meta_fields,
+                    keep_alive=config.pit_keep_alive,
+                )
+            else:
+                logging.info("Using Scroll API pagination.")
+                data_iter = client.extract_data(
+                    index_name, query, include_meta_fields=config.include_meta_fields
+                )
+
             with ElasticDictWriter(out_table.full_path, columns) as wr:
-                for result in client.extract_data(index_name, query, include_meta_fields=config.include_meta_fields):
+                for result in data_iter:
                     keys = _header_normalizer.normalize_header([k.lstrip("_") for k in result.keys()])
                     wr.writerow(dict(zip(keys, result.values())))
                 wr.writeheader()

--- a/src/configuration.py
+++ b/src/configuration.py
@@ -13,6 +13,11 @@ class AuthType(str, Enum):
     no_auth = "no_auth"
 
 
+class SearchMethod(str, Enum):
+    scroll = "scroll"
+    search_after = "search_after"
+
+
 class DbConfig(BaseModel):
     hostname: str
     port: int
@@ -74,6 +79,8 @@ class Configuration(BaseModel):
     primary_keys: list[str] = Field(default_factory=list)
     incremental: bool = False
     include_meta_fields: bool = False
+    search_method: SearchMethod = SearchMethod.scroll
+    pit_keep_alive: str = "5m"
     scheme: str = "http"
     # Legacy SSH dict — present means legacy mode
     ssh: Optional[dict] = None


### PR DESCRIPTION
## Summary

Adds Point-in-Time (PIT) + `search_after` as an alternative pagination method to the existing Scroll API, requested by a customer in [SUPPORT-16414](https://keboola.atlassian.net/browse/SUPPORT-16414).

**Changes:**
- **`src/configuration.py`**: Added `SearchMethod` enum (`scroll` / `search_after`) and two new config fields: `search_method` (default: `scroll`) and `pit_keep_alive` (default: `5m`).
- **`src/client/es_client.py`**: Added `extract_data_pit()` method that opens a PIT snapshot, paginates with `search_after`, and closes the PIT in a `finally` block. The `pit_id` is updated from every search response so the `finally` block always closes the most recently issued PIT ID.
- **`src/component.py`**: Routes extraction through `extract_data_pit()` or `extract_data()` based on the configured `search_method`.
- **`component_config/configRowSchema.json`**: Added `search_method` dropdown (Scroll API / PIT + search_after) and a conditional `pit_keep_alive` text field visible only when PIT is selected.

Existing Scroll API behavior is fully preserved as the default — no breaking changes.

## Review & Testing Checklist for Human

- [ ] Verify PIT + search_after works against an ES 7.10+ / 8.x cluster: create a config row with `"search_method": "search_after"` and confirm data is extracted correctly
- [ ] Verify the Scroll API path still works as before (default behavior, no config change needed)
- [ ] Test with a user-defined `sort` in the query body to ensure PIT respects it instead of injecting `_shard_doc`
- [ ] Test the PIT keep-alive field with different values (e.g. `1m`, `10m`) to confirm it propagates correctly
- [ ] Confirm PIT is closed even when extraction fails mid-way (error handling in `finally` block)

### Notes

- PIT requires ES 7.10+. The `elasticsearch` Python client v8.x used by this component supports `open_point_in_time` / `close_point_in_time` natively.
- The `_shard_doc` tiebreaker sort is used per [ES documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html#search-after) for efficient shard-level pagination when no explicit sort is provided.
- The `pit_keep_alive` UI field is conditionally visible only when `search_after` is selected, using `options.dependencies`.

## Release Notes
**Justification, description**

Customer feature request (SUPPORT-16414): add PIT (Point-in-Time) + `search_after` pagination as an alternative to the Scroll API. PIT is recommended by Elastic for ES 7.10+ and avoids long-lived scroll contexts that can strain clusters with large indices.

**Plans for Customer Communication**

Notify the requesting customer (TV Nova) that the feature is available and can be enabled by setting `search_method` to `search_after` in their row configuration.

**Impact Analysis**

Low risk — the default behavior is unchanged (Scroll API). PIT is additive and opt-in per row configuration.

**Deployment Plan**

Standard component deployment via Developer Portal tag.

**Rollback Plan**

Revert to previous tag. Customers using `search_after` would fall back to Scroll API (default).

**Post-Release Support Plan**

N/A

Link to Devin session: https://app.devin.ai/sessions/4bd6818829524068a73dc9bfd2e8e1e9
Requested by: @terezaskalova

[SUPPORT-16414]: https://keboola.atlassian.net/browse/SUPPORT-16414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ